### PR TITLE
Marcinj/token

### DIFF
--- a/app/src/main/java/cc/inflite/typeone/activities/MainActivity.java
+++ b/app/src/main/java/cc/inflite/typeone/activities/MainActivity.java
@@ -8,6 +8,7 @@ import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.Spinner;
 
+import cc.inflite.typeone.BuildConfig;
 import cc.inflite.typeone.R;
 import cc.inflite.typeone.data.PreferenceData;
 import cc.inflite.typeone.preferences.PreferenceStore;
@@ -15,6 +16,7 @@ import cc.inflite.typeone.preferences.PreferenceStore;
 public class MainActivity extends AppCompatActivity {
 
     private EditText editTextServerAddress;
+    private EditText editTextApiSecret;
     private Spinner spinner;
 
     @Override
@@ -23,6 +25,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         editTextServerAddress = findViewById(R.id.edittext_server_address);
+        editTextApiSecret = findViewById(R.id.edittext_api_secret);
         spinner = findViewById(R.id.spinner_update_frequency);
 
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(this,
@@ -32,6 +35,7 @@ public class MainActivity extends AppCompatActivity {
 
         PreferenceData preferenceData = PreferenceStore.getPreferences(getApplicationContext());
         editTextServerAddress.setText(preferenceData.getServerAddress());
+        editTextApiSecret.setText(preferenceData.getApiSecret());
         spinner.setSelection(adapter.getPosition(String.valueOf(preferenceData.getUpdateFrequency())));
     }
 
@@ -40,6 +44,6 @@ public class MainActivity extends AppCompatActivity {
         super.onPause();
 
         PreferenceStore.savePreferences(getApplicationContext(),
-                new PreferenceData(editTextServerAddress.getText().toString(), Integer.parseInt(spinner.getSelectedItem().toString())));
+                new PreferenceData(editTextServerAddress.getText().toString(), Integer.parseInt(spinner.getSelectedItem().toString()), editTextApiSecret.getText().toString()));
     }
 }

--- a/app/src/main/java/cc/inflite/typeone/data/PreferenceData.java
+++ b/app/src/main/java/cc/inflite/typeone/data/PreferenceData.java
@@ -3,15 +3,20 @@ package cc.inflite.typeone.data;
 public class PreferenceData {
 
     private final String serverAddress;
+    private final String apiSecret;
     private final int updateFrequency;
 
-    public PreferenceData(String serverAddress, int updateFrequency) {
+    public PreferenceData(String serverAddress, int updateFrequency, String apiSecret) {
         this.serverAddress = serverAddress;
         this.updateFrequency = updateFrequency;
+        this.apiSecret = apiSecret;
     }
 
     public String getServerAddress() {
         return serverAddress;
+    }
+    public String getApiSecret() {
+        return apiSecret;
     }
 
     public int getUpdateFrequency() {

--- a/app/src/main/java/cc/inflite/typeone/preferences/PreferenceStore.java
+++ b/app/src/main/java/cc/inflite/typeone/preferences/PreferenceStore.java
@@ -14,9 +14,11 @@ public class PreferenceStore {
 
     private static final String KEY_SERVER_ADDRESS = "ServerAddress";
     private static final String KEY_UPDATE_FREQUENCY = "UpdateFrequency";
+    private static final String KEY_API_SECRET = "ApiSecret";
 
     private static final String DEFAULT_SERVER_ADDRESS = "https://haspdenbloodglucose.herokuapp.com/api/v1/entries/sgv.json";
     private static final int DEFAULT_UPDATE_FREQUENCY = 30;
+    private static final String DEFAULT_API_SECRET = "";
 
     @NonNull
     public static PreferenceData getPreferences(@NonNull SdkContext sdkContext) {
@@ -24,6 +26,7 @@ public class PreferenceStore {
             KeyValueStore keyValueStore = sdkContext.getKeyValueStore();
             String serverAddress = keyValueStore.getString(KEY_SERVER_ADDRESS);
             String updateIntervalString = keyValueStore.getString(KEY_UPDATE_FREQUENCY);
+            String apiSecret = keyValueStore.getString(KEY_API_SECRET);
 
             if (serverAddress == null) {
                 serverAddress = DEFAULT_SERVER_ADDRESS;
@@ -34,12 +37,16 @@ public class PreferenceStore {
                 updateInterval = Integer.parseInt(updateIntervalString);
             }
 
-            return new PreferenceData(serverAddress, updateInterval);
+            if (apiSecret == null) {
+                apiSecret = DEFAULT_API_SECRET;
+            }
+
+            return new PreferenceData(serverAddress, updateInterval, apiSecret);
         } catch (Exception e) {
             Log.e(BuildConfig.APPLICATION_ID, "Unable to get preferences", e);
         }
 
-        return new PreferenceData(DEFAULT_SERVER_ADDRESS, DEFAULT_UPDATE_FREQUENCY);
+        return new PreferenceData(DEFAULT_SERVER_ADDRESS, DEFAULT_UPDATE_FREQUENCY, DEFAULT_API_SECRET);
     }
 
     @NonNull
@@ -53,6 +60,7 @@ public class PreferenceStore {
             KeyValueStore keyValueStore = sdkContext.getKeyValueStore();
             keyValueStore.putString(KEY_SERVER_ADDRESS, preferenceData.getServerAddress());
             keyValueStore.putString(KEY_UPDATE_FREQUENCY, String.valueOf(preferenceData.getUpdateFrequency()));
+            keyValueStore.putString(KEY_API_SECRET, preferenceData.getApiSecret());
             Log.d(BuildConfig.APPLICATION_ID, "Saved preferences");
         } catch (Exception e) {
             Log.e(BuildConfig.APPLICATION_ID, "Unable to save preferences", e);

--- a/app/src/main/java/cc/inflite/typeone/service/BackgroundServiceClient.java
+++ b/app/src/main/java/cc/inflite/typeone/service/BackgroundServiceClient.java
@@ -1,6 +1,7 @@
 package cc.inflite.typeone.service;
 
 import android.content.Context;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.google.gson.Gson;
@@ -9,9 +10,12 @@ import com.google.gson.reflect.TypeToken;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -54,7 +58,7 @@ public class BackgroundServiceClient {
             executor.submit(() -> {
                 try {
                     Log.i(BuildConfig.APPLICATION_ID, "Obtaining SGV data");
-                    this.sgvServiceData = new SGVServiceData(obtainSGVData(preferences.getServerAddress()), Instant.now());
+                    this.sgvServiceData = new SGVServiceData(obtainSGVData(preferences.getServerAddress(), preferences.getApiSecret()), Instant.now());
                 } catch (Exception e) {
                     Log.e(BuildConfig.APPLICATION_ID, "Unable to obtain data in the background: " + e);
                     this.sgvServiceData = new SGVServiceData(
@@ -69,12 +73,17 @@ public class BackgroundServiceClient {
         return sgvServiceData;
     }
 
-    private SGVData obtainSGVData(String serverUrl) throws Exception {
+    private SGVData obtainSGVData(String serverUrl, String apiSecret) throws Exception {
         HttpURLConnection connection = null;
 
         try {
             URL url = new URL(serverUrl);
             connection = (HttpURLConnection) url.openConnection();
+
+            if (!TextUtils.isEmpty(apiSecret)) {
+                String sha1 = SHA1(apiSecret);
+                connection.setRequestProperty("API-SECRET", sha1);
+            }
 
             if (connection.getResponseCode() != HttpsURLConnection.HTTP_OK) {
                 throw new IOException("Server returned code: " + connection.getResponseCode() + " for URL: " + url);
@@ -98,6 +107,33 @@ public class BackgroundServiceClient {
                 connection.disconnect();
             }
         }
+    }
+
+    private static String convertToHex(byte[] data) {
+        StringBuffer buf = new StringBuffer();
+        for (int i = 0; i < data.length; i++) {
+            int halfbyte = (data[i] >>> 4) & 0x0F;
+            int two_halfs = 0;
+            do {
+                if ((0 <= halfbyte) && (halfbyte <= 9)) {
+                    buf.append((char) ('0' + halfbyte));
+                }
+                else {
+                    buf.append((char) ('a' + (halfbyte - 10)));
+                }
+                halfbyte = data[i] & 0x0F;
+            } while(two_halfs++ < 1);
+        }
+        return buf.toString();
+    }
+
+
+    public static String SHA1(String text) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        byte[] sha1hash = new byte[40];
+        md.update(text.getBytes("iso-8859-1"), 0, text.length());
+        sha1hash = md.digest();
+        return convertToHex(sha1hash);
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,78 +7,114 @@
     android:padding="10dp"
     tools:context=".activities.MainActivity">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="120dp"
-            android:layout_marginBottom="10dp"
-            android:antialias="true"
-            android:scaleType="centerInside"
-            android:src="@drawable/inflite" />
-
+    <ScrollView android:id="@+id/scrollView1"
+        android:layout_height="fill_parent"
+        android:layout_width="fill_parent"
+        android:weightSum="1">
+        
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="10dp"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Nightscout API endpoint address:" android:textStyle="bold"/>
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="120dp"
+                android:layout_marginBottom="10dp"
+                android:antialias="true"
+                android:scaleType="centerInside"
+                android:src="@drawable/inflite" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="e.g. https://subdomain.domain.com/api/v1/entries/sgv.json"
-                android:textSize="12sp" />
-
-            <EditText
-                android:id="@+id/edittext_server_address"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:maxLines="1"
-                android:inputType="text"
-                android:scrollHorizontally="true" />
+                android:layout_marginVertical="10dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Nightscout API endpoint address:"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="e.g. https://subdomain.domain.com/api/v1/entries/sgv.json"
+                    android:textSize="12sp" />
+
+                <EditText
+                    android:id="@+id/edittext_server_address"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:scrollHorizontally="true" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="10dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginEnd="5dp"
+                    android:text="Update freq (secs):"
+                    android:textStyle="bold" />
+
+                <Spinner
+                    android:id="@+id/spinner_update_frequency"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="10dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Nightscout API Secret (optional)"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="12sp" />
+
+                <EditText
+                    android:id="@+id/edittext_api_secret"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:scrollHorizontally="true" />
+
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="Developed for INFLITE TYPE ONE by\nhttps://github.com/haspden\nhttps://github.com/valterc"
+                android:textSize="12sp"
+                android:textStyle="italic"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent" /> 
 
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginVertical="10dp"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginEnd="5dp"
-                android:text="Update freq (secs):" android:textStyle="bold"/>
-
-            <Spinner
-                android:id="@+id/spinner_update_frequency"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-        </LinearLayout>
-
-    </LinearLayout>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="Developed for INFLITE TYPE ONE by\nhttps://github.com/haspden\nhttps://github.com/valterc"
-        android:textSize="12sp"
-        android:textStyle="italic"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent" />
+    </ScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This change allows the user to specify API_SECRET to be used when making calls to Nightscout APIs.

This is needed for anybody who has set the default permission on their Nightscout instance to denied, making un-authenticated API calls return 401 Unathorized.

I tested it on my own Karoo 2 and Nightscout instance.

Here's the UI in an android emulator:

![image](https://user-images.githubusercontent.com/6841973/221654131-debe907f-08ba-430e-be67-c6c4b76e42f1.png)
